### PR TITLE
Detected Buildpacks added to CF Exporter

### DIFF
--- a/collectors/applications_collector.go
+++ b/collectors/applications_collector.go
@@ -213,10 +213,15 @@ func (c ApplicationsCollector) reportApplicationsMetrics(ch chan<- prometheus.Me
 			continue
 		}
 
+		buildpack := application.DetectedBuildpack
+		if buildpack == "" {
+			buildpack = application.Buildpack
+		}
+
 		c.applicationInfoMetric.WithLabelValues(
 			application.Guid,
 			application.Name,
-			application.Buildpack,
+			buildpack,
 			organization.Guid,
 			organization.Name,
 			space.Guid,


### PR DESCRIPTION
I noticed that if the buildpack is not manually selected in the cf push or in the manifest, prometheus picks it up as "buildpack" and not the actual buildpack name 

This pr should allow the cf_exporter to return detected buildpacks (selected by CF) instead of listing them generically as 'buildpack'